### PR TITLE
Generalize speculative decoding to sampling

### DIFF
--- a/experiments/spec_sampled.cfg
+++ b/experiments/spec_sampled.cfg
@@ -1,0 +1,11 @@
+[config]
+
+target_model = Qwen/Qwen2.5-7B-Instruct
+draft_model = Qwen/Qwen2.5-0.5B-Instruct
+language_code = ber
+draft_model_type = neural
+decoding_mode = sample
+task = translation
+data_source = tatoeba
+gamma = 5
+max_samples = 50

--- a/run.py
+++ b/run.py
@@ -51,7 +51,10 @@ def run(config: ExperimentConfig):
         draft_model = None
         draft_tokenizer = None
     elif config.draft_model_type == "neural":
-        assert config.draft_model is not None
+        if config.draft_model is None:
+            raise ValueError(
+                "draft_model must be set when draft_model_type='neural'"
+            )
         logger.info(f"Loading draft model: {config.draft_model}...")
         if config.draft_model != config.target_model:
             draft_model, draft_tokenizer = load_model(

--- a/run.py
+++ b/run.py
@@ -51,13 +51,13 @@ def run(config: ExperimentConfig):
         draft_model = None
         draft_tokenizer = None
     elif config.draft_model_type == "neural":
-        if config.draft_model is not None:
-            logger.info(f"Loading draft model: {config.draft_model}...")
+        assert config.draft_model is not None
+        logger.info(f"Loading draft model: {config.draft_model}...")
+        if config.draft_model != config.target_model:
             draft_model, draft_tokenizer = load_model(
                 config.draft_model, device=config.device
             )
         else:
-            logger.info("No draft model specified, using target as draft.")
             draft_model = target_model
             draft_tokenizer = target_tokenizer
     elif config.draft_model_type == "ngram":
@@ -110,7 +110,10 @@ def setup_wandb(config: ExperimentConfig):
     if config.draft_model_type == 'ngram':
         draft_short = "ngram"
     elif config.draft_model_type == 'neural':
-        draft_short = config.draft_model.split("/")[-1] # type:ignore
+        if config.draft_model:
+            draft_short = config.draft_model.split("/")[-1] # type:ignore
+        else:
+            draft_short = target_short
     else:
         draft_short = None
         

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -11,7 +11,7 @@ class ExperimentConfig:
     draft_model: str | None
     draft_model_type: Literal["none", "neural", "ngram"]
    
-    decoding_mode: Literal["greedy", "top_k", "top_p"]
+    decoding_mode: Literal["greedy", "sample"]
     gamma: int = 5
     track_iterations: bool = False # If true, will log per-iteration of SD
     
@@ -31,3 +31,4 @@ class ExperimentConfig:
             
         if self.draft_model_type == 'neural':
             assert self.gamma > 0
+            assert self.draft_model is not None

--- a/src/generation.py
+++ b/src/generation.py
@@ -6,7 +6,7 @@ from transformers import PreTrainedModel, PreTrainedTokenizer
 
 from src.config.config import ExperimentConfig
 from src.n_gram import NGramModel
-from src.spec_decode import speculative_decode_greedy
+from src.spec_decode import speculative_decode
 
 
 def generate_output(
@@ -26,11 +26,12 @@ def generate_output(
 
     # Use our custom spec dec implementation
     if config.draft_model_type != "none" and not config.use_hf_assisted:
-        output_ids, metrics = speculative_decode_greedy(
+        output_ids, metrics = speculative_decode(
             target_model=model,
             draft_model=draft_model,
             tokenizer=tokenizer,
             input_ids=inputs["input_ids"],
+            mode=config.decoding_mode,
             max_new_tokens=config.max_new_tokens,
             gamma=config.gamma,  # type:ignore
             device=inputs["input_ids"].device,

--- a/src/generation.py
+++ b/src/generation.py
@@ -26,6 +26,8 @@ def generate_output(
 
     # Use our custom spec dec implementation
     if config.draft_model_type != "none" and not config.use_hf_assisted:
+        if not same_tokenizer:
+            raise NotImplementedError("SD with different tokenizers not implemented.")
         output_ids, metrics = speculative_decode(
             target_model=model,
             draft_model=draft_model,

--- a/src/spec_decode.py
+++ b/src/spec_decode.py
@@ -6,8 +6,12 @@ Contains:
 - get_stop_token_ids: Stop token detection for various chat models
 - crop_kv_cache: KV cache management utility
 """
+
 import time
+from typing import Literal
+
 import torch
+
 
 def get_stop_token_ids(tokenizer, eos_token_id=None):
     """
@@ -15,23 +19,23 @@ def get_stop_token_ids(tokenizer, eos_token_id=None):
     Supports: Qwen, Llama, Mistral, Gemma, and others.
     """
     stop_ids = set()
-    
+
     if eos_token_id is not None:
         stop_ids.add(eos_token_id)
     if tokenizer.eos_token_id is not None:
         stop_ids.add(tokenizer.eos_token_id)
-    
+
     stop_tokens = [
-        "<|im_end|>",        # Qwen
-        "<|endoftext|>",     # Qwen, GPT
-        "<|eot_id|>",        # Llama 3
-        "<|end_of_text|>",   # Llama 3
-        "</s>",              # Mistral, Llama 2
-        "<end_of_turn>",     # Gemma
-        "<eos>",             # Gemma
-        "[/INST]",           # Mistral
+        "<|im_end|>",  # Qwen
+        "<|endoftext|>",  # Qwen, GPT
+        "<|eot_id|>",  # Llama 3
+        "<|end_of_text|>",  # Llama 3
+        "</s>",  # Mistral, Llama 2
+        "<end_of_turn>",  # Gemma
+        "<eos>",  # Gemma
+        "[/INST]",  # Mistral
     ]
-    
+
     for token in stop_tokens:
         try:
             ids = tokenizer.encode(token, add_special_tokens=False)
@@ -39,7 +43,7 @@ def get_stop_token_ids(tokenizer, eos_token_id=None):
                 stop_ids.add(ids[0])
         except Exception:
             pass
-    
+
     return stop_ids
 
 
@@ -50,8 +54,8 @@ def crop_kv_cache(past_key_values, new_length):
     """
     if past_key_values is None:
         return None
-    
-    if hasattr(past_key_values, 'crop'):
+
+    if hasattr(past_key_values, "crop"):
         past_key_values.crop(new_length)
         return past_key_values
     else:
@@ -85,49 +89,62 @@ def get_kv_cache_length(past_key_values) -> int:
     return 0
 
 
-def speculative_decode_greedy(
+def speculative_decode(
     target_model,
     draft_model,
     tokenizer,
     input_ids: torch.Tensor,
+    mode: Literal["greedy", "sample"],
     max_new_tokens: int = 256,
     gamma: int = 5,
     eos_token_id: int | None = None,
     device=None,
-    track_iterations: bool = False
+    track_iterations: bool = False,
 ):
     """
     Speculative Decoding with KV Caching.
     Key features:
-    
+
     Args:
         target_model: The large target model
         draft_model: The smaller draft model
         tokenizer: Shared tokenizer (must be same for both models)
         input_ids: Input token IDs [1, seq_len]
+        mode: 'greedy' | 'sample'
         max_new_tokens: Maximum new tokens to generate
         gamma: Number of draft tokens to generate per iteration
         eos_token_id: End of sequence token ID
         device: Device to run on
-    
+
     Returns:
         output_ids: Generated token IDs
         metrics: Dict with acceptance_rate, time, draft_tokens, matched_tokens, etc.
     """
-    assert input_ids.shape[0] == 1, "Speculative decoding only supports batch_size=1"
-    
+    bs = input_ids.size(0)
+    assert bs == 1, "Speculative decoding only supports batch_size=1"
+
     if device is None:
         device = next(target_model.parameters()).device
-    
-    stop_token_ids = torch.tensor(list(get_stop_token_ids(tokenizer, eos_token_id)), device=device)
+
+    if mode == "greedy":
+        select_index = _greedy
+    elif mode == "sample":
+        select_index = _sample
+
+    stop_token_ids = torch.tensor(
+        list(get_stop_token_ids(tokenizer, eos_token_id)), device=device
+    )
     input_ids = input_ids.to(device)
 
     # B,S+max_new
     generated_tokens = torch.concat(
         [
             input_ids,
-            torch.zeros(input_ids.size(0), max_new_tokens, device=device, dtype=torch.int64),
-        ], dim=-1
+            torch.zeros(
+                input_ids.size(0), max_new_tokens, device=device, dtype=torch.int64
+            ),
+        ],
+        dim=-1,
     )
     cur_gen_idx = input_ids.size(1)
 
@@ -137,42 +154,46 @@ def speculative_decode_greedy(
         target_out = target_model(input_ids, use_cache=True)
         target_kv_cache = target_out.past_key_values
         draft_kv_cache = draft_model(input_ids, use_cache=True).past_key_values
+        d_vocab = target_out.logits.size(-1)
 
         # Add the first new token
-        last_target_token = target_out.logits[:,-1,:].argmax(dim=-1)
+        last_target_token = select_index(
+            torch.log_softmax(target_out.logits[:, -1, :], dim=-1)
+        )
         generated_tokens[:, cur_gen_idx] = last_target_token
         cur_gen_idx += 1
-        
+
         # Metrics
         total_draft_tokens = 0
-        total_matched_tokens = 0  
+        total_matched_tokens = 0
         num_iterations = 0
         iteration_history = []
         if is_cuda:
             torch.cuda.synchronize()
         start_time = time.time()
-        
+
         while cur_gen_idx < generated_tokens.size(-1):
             num_iterations += 1
             # Step 1: Draft tokens
             # B * gamma (unless gamma > remaining tokens)
+            max_draft_tokens = min(gamma, generated_tokens.size(-1) - cur_gen_idx)
             new_draft_tokens = torch.zeros(
-                (
-                    input_ids.size(0),
-                    min(gamma, generated_tokens.size(-1) - cur_gen_idx),
-                ),
+                (bs, max_draft_tokens),
                 device=input_ids.device,
-                dtype=torch.int64
+                dtype=torch.int64,
             )
-            
+            new_draft_token_logprobs = torch.zeros(
+                (bs, max_draft_tokens, d_vocab), device=input_ids.device
+            )
+
             # Determine how many tokens the draft model is missing from its cache
             cache_len = get_kv_cache_length(draft_kv_cache)
             expected_len = cur_gen_idx - 1
             if cache_len < expected_len:
                 draft_input_ids = generated_tokens[:, cache_len:cur_gen_idx]
             else:
-                draft_input_ids = generated_tokens[:, cur_gen_idx-1:cur_gen_idx]
-            
+                draft_input_ids = generated_tokens[:, cur_gen_idx - 1 : cur_gen_idx]
+
             for idx in range(new_draft_tokens.size(-1)):
                 draft_out = draft_model(
                     input_ids=draft_input_ids,
@@ -180,94 +201,144 @@ def speculative_decode_greedy(
                     use_cache=True,
                 )
                 draft_kv_cache = draft_out.past_key_values
-                next_draft_token = draft_out.logits[:, -1, :].argmax(dim=-1)
+                draft_out_logprobs = torch.log_softmax(
+                    draft_out.logits[:, -1, :], dim=-1
+                )
+                next_draft_token = select_index(draft_out_logprobs)  # (bs,)
                 new_draft_tokens[:, idx] = next_draft_token
+                new_draft_token_logprobs[:, idx] = draft_out_logprobs
                 draft_input_ids = next_draft_token.unsqueeze(-1)
                 if torch.isin(next_draft_token, stop_token_ids).any():
                     # Trim draft tokens tensor since it's shorter than usual
-                    new_draft_tokens = new_draft_tokens[:,:idx+1]
+                    new_draft_tokens = new_draft_tokens[:, : idx + 1]
+                    new_draft_token_logprobs = new_draft_token_logprobs[:, : idx + 1, :]
                     break
-            
+
             #  Step 2: Target model verifies
-            target_input_ids = torch.concat([
-                generated_tokens[:, cur_gen_idx-1:cur_gen_idx],
-                new_draft_tokens
-            ], dim=-1)
+            target_input_ids = torch.concat(
+                [generated_tokens[:, cur_gen_idx - 1 : cur_gen_idx], new_draft_tokens],
+                dim=-1,
+            )
             target_out = target_model(
                 input_ids=target_input_ids,
                 past_key_values=target_kv_cache,
                 use_cache=True,
             )
             # Find the first collision, if any
-            target_preds_for_draft = target_out.logits.argmax(dim=-1)
-            collisions = (new_draft_tokens != target_preds_for_draft[:,:-1])
-            total_draft_tokens += collisions.size(-1)
-            if collisions.any():
-                first_collision_idx = collisions.int().argmax(dim=-1).min().item()
+            target_out_logprobs = torch.log_softmax(
+                target_out.logits, dim=-1
+            )  # (bs,seq,d_vocab)
+            target_out_chosen_logprobs = target_out_logprobs.gather(
+                -1, new_draft_tokens.unsqueeze(-1)
+            ).squeeze(-1)  # (bs,seq)
+            draft_out_chosen_logprobs = new_draft_token_logprobs.gather(
+                -1, new_draft_tokens.unsqueeze(-1)
+            ).squeeze(-1) # (bs,seq)
+
+            # First, check if p_draft(t) <= p_target(t)
+            lower_draft_prob = draft_out_chosen_logprobs <= target_out_chosen_logprobs
+
+            # If this fails, we still accept a token with p = p_target(t) / p_draft(t)
+            random_accept = target_out_chosen_logprobs - draft_out_chosen_logprobs
+            random_accept = (
+                torch.log(torch.rand_like(target_out_chosen_logprobs)) < random_accept
+            )
+
+            # Figure out the first rejected token
+            rejected = ~(lower_draft_prob | random_accept)
+            total_draft_tokens += rejected.size(-1)
+            if rejected.any():
+                first_collision_idx = rejected.int().argmax(dim=-1).item()
+                assert isinstance(first_collision_idx, int)
+                total_matched_tokens += first_collision_idx
+
+                # Resample token from p_target(x) - p_draft(x)
+                resample_dist = (
+                    torch.exp(target_out_logprobs[:, first_collision_idx])
+                    - torch.exp(new_draft_token_logprobs[:, first_collision_idx])
+                ).clamp(min=0)
+                resample_dist = resample_dist / resample_dist.sum(dim=-1, keepdim=True)
+                resample_dist = torch.log(resample_dist)
+                resampled_token = select_index(resample_dist)
+
                 tokens_to_add = torch.concat(
                     [
                         new_draft_tokens[:, :first_collision_idx],
-                        target_preds_for_draft[:, first_collision_idx].unsqueeze(-1),
+                        resampled_token.unsqueeze(-1),
                     ],
                     dim=-1,
                 )
-                total_matched_tokens += first_collision_idx
             else:
-                if torch.isin(new_draft_tokens[:,-1], stop_token_ids).any():
+                if torch.isin(new_draft_tokens[:, -1], stop_token_ids).any():
                     # If we've reached <eos>, don't add bonus token
                     tokens_to_add = new_draft_tokens
-
                 else:
                     # If no collision, add all draft tokens plus the bonus token (if room)
-                    if cur_gen_idx + new_draft_tokens.size(-1) < generated_tokens.size(-1):
+                    if cur_gen_idx + new_draft_tokens.size(-1) < generated_tokens.size(
+                        -1
+                    ):
+                        bonus_token = select_index(target_out_logprobs[:, -1])
                         tokens_to_add = torch.concat(
-                            [new_draft_tokens, target_preds_for_draft[:, -1].unsqueeze(-1)],
+                            [
+                                new_draft_tokens,
+                                bonus_token.unsqueeze(-1),
+                            ],
                             dim=-1,
                         )
                     else:
                         tokens_to_add = new_draft_tokens
 
                 total_matched_tokens += new_draft_tokens.size(-1)
+
             # Actually add the new tokens and update idxs
             new_gen_idx = cur_gen_idx + tokens_to_add.size(-1)
-            generated_tokens[:, cur_gen_idx : new_gen_idx] = tokens_to_add
+            generated_tokens[:, cur_gen_idx:new_gen_idx] = tokens_to_add
             cur_gen_idx = new_gen_idx
-            
+
             # Update kv caches
             # Either cache should not include the last generated tok (either correction or bonus token)
             target_kv_cache = crop_kv_cache(target_kv_cache, new_gen_idx - 1)
             draft_kv_cache = crop_kv_cache(draft_kv_cache, new_gen_idx - 1)
-            
+
             if track_iterations:
                 # FIXME: If we ever do batching this is wrong
                 draft_ids = new_draft_tokens[0].tolist()
                 draft_text = [tokenizer.decode([tid]) for tid in draft_ids]
                 last_token_str = tokenizer.decode([int(tokens_to_add[0, -1].item())])
-                if not collisions.any():
-                    result = f"ALL ACCEPTED ({len(draft_ids)}) + BONUS '{last_token_str}'"
+                if not rejected.any():
+                    result = (
+                        f"ALL ACCEPTED ({len(draft_ids)}) + BONUS '{last_token_str}'"
+                    )
                 else:
-                    first_collision_idx = collisions.int().argmax(dim=-1).item()
-                    rejected_str = tokenizer.decode([new_draft_tokens[0][first_collision_idx].item()])
+                    first_collision_idx = rejected.int().argmax(dim=-1).item()
+                    assert isinstance(first_collision_idx, int)
+                    rejected_str = tokenizer.decode(
+                        [new_draft_tokens[0][first_collision_idx].item()]
+                    )
                     result = f"ACCEPTED {first_collision_idx}, REJECTED '{rejected_str}' -> TARGET '{last_token_str}'"
-                iteration_history.append({
-                    "iter": len(iteration_history),
-                    "drafted": draft_text,
-                    "result": result,
-                })
+                iteration_history.append(
+                    {
+                        "iter": len(iteration_history),
+                        "drafted": draft_text,
+                        "result": result,
+                    }
+                )
 
-            if torch.isin(generated_tokens[:,cur_gen_idx-1], stop_token_ids).any():
+            if torch.isin(generated_tokens[:, cur_gen_idx - 1], stop_token_ids).any():
                 # Get rid of extra 0s
-                generated_tokens = generated_tokens[:,:cur_gen_idx]
+                generated_tokens = generated_tokens[:, :cur_gen_idx]
                 break
-    
+
     if is_cuda:
         torch.cuda.synchronize()
     total_time = time.time() - start_time
-    
+
     # Calculate acceptance rate (matched draft tokens / total draft tokens)
-    acceptance_rate = total_matched_tokens / total_draft_tokens if total_draft_tokens > 0 else 0.0
+    acceptance_rate = (
+        total_matched_tokens / total_draft_tokens if total_draft_tokens > 0 else 0.0
+    )
     total_generated_tokens = cur_gen_idx - input_ids.size(1)
-    
+
     metrics = {
         "time": total_time,
         "generated_tokens": total_generated_tokens,
@@ -280,17 +351,16 @@ def speculative_decode_greedy(
 
     if track_iterations:
         metrics["iteration_history"] = iteration_history
-    
+
     return generated_tokens, metrics
 
 
+def _greedy(logprobs: torch.Tensor):
+    return logprobs.argmax(dim=-1)
 
-def speculative_decode_with_sampling():
-    """Speculative decoding with nucleus/temperature sampling."""
-    raise NotImplementedError(
-        "Sampling-based speculative decoding not implemented yet. "
-        "Use speculative_decode_greedy for greedy decoding."
-    )
+
+def _sample(logprobs: torch.Tensor):
+    return torch.multinomial(torch.exp(logprobs), num_samples=1).squeeze(-1)
 
 
 def speculative_decode_different_tokenizers():

--- a/src/spec_decode.py
+++ b/src/spec_decode.py
@@ -136,6 +136,10 @@ def speculative_decode(
     )
     input_ids = input_ids.to(device)
 
+    # This is okay because if we've gotten this far, we know the actual tokenizers are the same length.
+    # Just be aware that logits may have a slightly shorter dimension
+    d_vocab = max(draft_model.config.vocab_size, target_model.config.vocab_size)
+
     # B,S+max_new
     generated_tokens = torch.concat(
         [
@@ -154,7 +158,6 @@ def speculative_decode(
         target_out = target_model(input_ids, use_cache=True)
         target_kv_cache = target_out.past_key_values
         draft_kv_cache = draft_model(input_ids, use_cache=True).past_key_values
-        d_vocab = target_out.logits.size(-1)
 
         # Add the first new token
         last_target_token = select_index(
@@ -182,8 +185,10 @@ def speculative_decode(
                 device=input_ids.device,
                 dtype=torch.int64,
             )
-            new_draft_token_logprobs = torch.zeros(
-                (bs, max_draft_tokens, d_vocab), device=input_ids.device
+            new_draft_token_logprobs = torch.full(
+                (bs, max_draft_tokens, d_vocab),
+                fill_value=float("-inf"),
+                device=input_ids.device,
             )
 
             # Determine how many tokens the draft model is missing from its cache
@@ -206,7 +211,9 @@ def speculative_decode(
                 )
                 next_draft_token = select_index(draft_out_logprobs)  # (bs,)
                 new_draft_tokens[:, idx] = next_draft_token
-                new_draft_token_logprobs[:, idx] = draft_out_logprobs
+                new_draft_token_logprobs[:, idx, : draft_out_logprobs.shape[-1]] = (
+                    draft_out_logprobs
+                )
                 draft_input_ids = next_draft_token.unsqueeze(-1)
                 if torch.isin(next_draft_token, stop_token_ids).any():
                     # Trim draft tokens tensor since it's shorter than usual
@@ -228,12 +235,12 @@ def speculative_decode(
             target_out_logprobs = torch.log_softmax(
                 target_out.logits, dim=-1
             )  # (bs,seq,d_vocab)
-            target_out_chosen_logprobs = target_out_logprobs.gather(
+            target_out_chosen_logprobs = target_out_logprobs[:,:-1,:].gather(
                 -1, new_draft_tokens.unsqueeze(-1)
             ).squeeze(-1)  # (bs,seq)
             draft_out_chosen_logprobs = new_draft_token_logprobs.gather(
                 -1, new_draft_tokens.unsqueeze(-1)
-            ).squeeze(-1) # (bs,seq)
+            ).squeeze(-1)  # (bs,seq)
 
             # First, check if p_draft(t) <= p_target(t)
             lower_draft_prob = draft_out_chosen_logprobs <= target_out_chosen_logprobs
@@ -360,7 +367,7 @@ def _greedy(logprobs: torch.Tensor):
 
 
 def _sample(logprobs: torch.Tensor):
-    return torch.multinomial(torch.exp(logprobs), num_samples=1).squeeze(-1)
+    return torch.distributions.Categorical(logits=logprobs).sample()
 
 
 def speculative_decode_different_tokenizers():

--- a/src/spec_decode.py
+++ b/src/spec_decode.py
@@ -126,10 +126,8 @@ def speculative_decode(
     if device is None:
         device = next(target_model.parameters()).device
 
-    if mode == "greedy":
-        select_index = _greedy
-    elif mode == "sample":
-        select_index = _sample
+    def select_index(logits: torch.Tensor):
+        return sample(logits, mode)
 
     stop_token_ids = torch.tensor(
         list(get_stop_token_ids(tokenizer, eos_token_id)), device=device
@@ -362,12 +360,14 @@ def speculative_decode(
     return generated_tokens, metrics
 
 
-def _greedy(logprobs: torch.Tensor):
-    return logprobs.argmax(dim=-1)
 
-
-def _sample(logprobs: torch.Tensor):
-    return torch.distributions.Categorical(logits=logprobs).sample()
+def sample(logprobs: torch.Tensor, mode: Literal["greedy", "sample"]):
+    # TODO: Add top-k and top-p
+    
+    if mode == "greedy":
+        return logprobs.argmax(dim=-1)
+    else:
+        return torch.distributions.Categorical(logits=logprobs).sample()
 
 
 def speculative_decode_different_tokenizers():


### PR DESCRIPTION
Implements sampled speculative decoding. When we generate a token from the draft model with probability `q(x)` and probability in the base model `p(x)`, we check:

1. If `q(x) <= p(x)`, always accept the token
2. If `q(x) > p(x)`, accept the token with probability `p(x) / q(x)`
3. If (2) rejects the token, sample a new token from the reweighted distribution `P(x) - Q(x)`.

Greedy decoding is a special case of this, so the function is exactly the same. I've implemented everything with logprobs for numerical stability. I haven't implemented top-k or nucleus sampling, but this is pretty trivial---just add a filter to the logits in the `_sample` function.